### PR TITLE
Update module dependency to include gitlab.com/opennota/check

### DIFF
--- a/tools/tools.go
+++ b/tools/tools.go
@@ -17,5 +17,6 @@
 package tools
 
 import (
+	_ "gitlab.com/opennota/check"
 	_ "gitlab.com/opennota/check/cmd/varcheck"
 )

--- a/vendor/gitlab.com/opennota/check/.gitlab-ci.yml
+++ b/vendor/gitlab.com/opennota/check/.gitlab-ci.yml
@@ -1,0 +1,20 @@
+image: golang:1.11
+
+stages:
+  - build
+  - test
+
+before_script:
+  - mkdir -p /go/src/gitlab.com/opennota
+  - ln -s /builds/opennota/check /go/src/gitlab.com/opennota/
+
+build:
+  stage: build
+  script:
+    - go build ./...
+
+test:
+  stage: test
+  script:
+    - test -z "$(gofmt -l . | tee /dev/stderr)"
+    - go test ./...

--- a/vendor/gitlab.com/opennota/check/README.md
+++ b/vendor/gitlab.com/opennota/check/README.md
@@ -1,0 +1,77 @@
+check [![License](http://img.shields.io/:license-gpl3-blue.svg)](http://www.gnu.org/licenses/gpl-3.0.html) [![Pipeline status](https://gitlab.com/opennota/check/badges/master/pipeline.svg)](https://gitlab.com/opennota/check/commits/master)
+=====
+
+A set of utilities for checking Go sources.
+
+## Install
+
+    go get -u gitlab.com/opennota/check/cmd/aligncheck
+    go get -u gitlab.com/opennota/check/cmd/structcheck
+    go get -u gitlab.com/opennota/check/cmd/varcheck
+
+## Use
+
+Find inefficiently packed structs.
+
+
+```
+$ aligncheck net/http
+net/http: /usr/lib/go/src/net/http/server.go:123:6: struct conn could have size 160 (currently 168)
+net/http: /usr/lib/go/src/net/http/server.go:315:6: struct response could have size 152 (currently 176)
+net/http: /usr/lib/go/src/net/http/transfer.go:37:6: struct transferWriter could have size 96 (currently 112)
+net/http: /usr/lib/go/src/net/http/transport.go:49:6: struct Transport could have size 136 (currently 144)
+net/http: /usr/lib/go/src/net/http/transport.go:811:6: struct persistConn could have size 160 (currently 176)
+
+```
+For the visualisation of struct packing see http://golang-sizeof.tips/
+
+Find unused struct fields.
+
+```
+$ structcheck --help
+Usage of structcheck:
+  -a    Count assignments only
+  -e    Report exported fields
+  -t    Load test files too
+
+$ structcheck fmt
+fmt: /usr/lib/go/src/fmt/format.go:47:2: fmt.fmtFlags.zero
+fmt: /usr/lib/go/src/fmt/format.go:41:2: fmt.fmtFlags.minus
+fmt: /usr/lib/go/src/fmt/format.go:42:2: fmt.fmtFlags.plus
+fmt: /usr/lib/go/src/fmt/format.go:43:2: fmt.fmtFlags.sharp
+fmt: /usr/lib/go/src/fmt/format.go:44:2: fmt.fmtFlags.space
+fmt: /usr/lib/go/src/fmt/format.go:52:2: fmt.fmtFlags.plusV
+fmt: /usr/lib/go/src/fmt/format.go:53:2: fmt.fmtFlags.sharpV
+fmt: /usr/lib/go/src/fmt/format.go:39:2: fmt.fmtFlags.widPresent
+fmt: /usr/lib/go/src/fmt/format.go:40:2: fmt.fmtFlags.precPresent
+fmt: /usr/lib/go/src/fmt/format.go:45:2: fmt.fmtFlags.unicode
+fmt: /usr/lib/go/src/fmt/format.go:46:2: fmt.fmtFlags.uniQuote
+fmt: /usr/lib/go/src/fmt/print.go:110:2: fmt.pp.n
+fmt: /usr/lib/go/src/fmt/scan.go:179:2: fmt.ssave.nlIsEnd
+fmt: /usr/lib/go/src/fmt/scan.go:180:2: fmt.ssave.nlIsSpace
+fmt: /usr/lib/go/src/fmt/scan.go:181:2: fmt.ssave.argLimit
+fmt: /usr/lib/go/src/fmt/scan.go:182:2: fmt.ssave.limit
+fmt: /usr/lib/go/src/fmt/scan.go:183:2: fmt.ssave.maxWid
+```
+
+Find unused global variables and constants.
+
+```
+$ varcheck --help
+Usage of varcheck:
+  -e=false: Report exported variables and constants
+
+$ varcheck image/jpeg
+image/jpeg: /usr/lib/go/src/image/jpeg/reader.go:74:2: adobeTransformYCbCr
+image/jpeg: /usr/lib/go/src/image/jpeg/reader.go:75:2: adobeTransformYCbCrK
+image/jpeg: /usr/lib/go/src/image/jpeg/writer.go:54:2: quantIndexLuminance
+image/jpeg: /usr/lib/go/src/image/jpeg/writer.go:55:2: quantIndexChrominance
+image/jpeg: /usr/lib/go/src/image/jpeg/writer.go:91:2: huffIndexLuminanceDC
+image/jpeg: /usr/lib/go/src/image/jpeg/writer.go:92:2: huffIndexLuminanceAC
+image/jpeg: /usr/lib/go/src/image/jpeg/writer.go:93:2: huffIndexChrominanceDC
+image/jpeg: /usr/lib/go/src/image/jpeg/writer.go:94:2: huffIndexChrominanceAC
+```
+
+## Known limitations
+
+structcheck doesn't handle embedded structs yet.

--- a/vendor/gitlab.com/opennota/check/common.go
+++ b/vendor/gitlab.com/opennota/check/common.go
@@ -1,0 +1,14 @@
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package check

--- a/vendor/gitlab.com/opennota/check/go.mod
+++ b/vendor/gitlab.com/opennota/check/go.mod
@@ -1,0 +1,3 @@
+module gitlab.com/opennota/check
+
+require golang.org/x/tools v0.0.0-20180911133044-677d2ff680c1

--- a/vendor/gitlab.com/opennota/check/go.sum
+++ b/vendor/gitlab.com/opennota/check/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/tools v0.0.0-20180911133044-677d2ff680c1 h1:dzEuQYa6+a3gROnSlgly5ERUm4SZKJt+dh+4iSbO+bI=
+golang.org/x/tools v0.0.0-20180911133044-677d2ff680c1/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -128,6 +128,7 @@ github.com/ulikunitz/xz/internal/xlog
 github.com/ulikunitz/xz/lzma
 # gitlab.com/opennota/check v0.0.0-20181224073239-ccaba434e62a
 ## explicit
+gitlab.com/opennota/check
 gitlab.com/opennota/check/cmd/varcheck
 # golang.org/x/mod v0.3.0
 golang.org/x/mod/semver


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Adds a dependency on "gitlab.com/opennota/check" to ensure that
the top-level directory that contains the go.mod file is vendored.
Required to propertly amalgomate this check in module mode.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

